### PR TITLE
V6/score calculation fix

### DIFF
--- a/abi/CommitManagerV1.json
+++ b/abi/CommitManagerV1.json
@@ -23,6 +23,11 @@
         "type": "uint16"
       },
       {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
+      },
+      {
         "internalType": "uint256",
         "name": "commitWindowOpen",
         "type": "uint256"
@@ -70,6 +75,11 @@
         "type": "uint16"
       },
       {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
+      },
+      {
         "internalType": "uint72",
         "name": "identityId",
         "type": "uint72"
@@ -94,6 +104,11 @@
         "internalType": "uint16",
         "name": "epoch",
         "type": "uint16"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
       },
       {
         "internalType": "uint72",

--- a/abi/ProofManagerV1.json
+++ b/abi/ProofManagerV1.json
@@ -23,6 +23,11 @@
         "type": "uint16"
       },
       {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
+      },
+      {
         "internalType": "uint72",
         "name": "identityId",
         "type": "uint72"
@@ -47,6 +52,11 @@
         "internalType": "uint16",
         "name": "epoch",
         "type": "uint16"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
       },
       {
         "internalType": "uint72",
@@ -89,6 +99,11 @@
         "internalType": "uint16",
         "name": "epoch",
         "type": "uint16"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
       },
       {
         "internalType": "uint256",
@@ -157,6 +172,11 @@
         "internalType": "uint16",
         "name": "epoch",
         "type": "uint16"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "state",
+        "type": "bytes32"
       },
       {
         "internalType": "uint72",

--- a/abi/ServiceAgreementStorageV1U1.json
+++ b/abi/ServiceAgreementStorageV1U1.json
@@ -77,6 +77,39 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "commitId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint72",
+        "name": "prevIdentityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint72",
+        "name": "nextIdentityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint40",
+        "name": "score",
+        "type": "uint40"
+      }
+    ],
+    "name": "createEpochStateCommitSubmissionObject",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "agreementId",
         "type": "bytes32"
       },
@@ -107,39 +140,6 @@
       }
     ],
     "name": "createServiceAgreementObject",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "commitId",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint72",
-        "name": "prevIdentityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint72",
-        "name": "nextIdentityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint40",
-        "name": "score",
-        "type": "uint40"
-      }
-    ],
-    "name": "createStateCommitSubmissionObject",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -179,6 +179,19 @@
     "inputs": [
       {
         "internalType": "bytes32",
+        "name": "commitId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "deleteEpochStateCommitSubmissionsObject",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
         "name": "epochStateId",
         "type": "bytes32"
       }
@@ -205,11 +218,11 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "commitId",
+        "name": "stateId",
         "type": "bytes32"
       }
     ],
-    "name": "deleteStateCommitSubmissionsObject",
+    "name": "deleteUpdateCommitsDeadline",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -218,13 +231,19 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "stateId",
+        "name": "commitId",
         "type": "bytes32"
       }
     ],
-    "name": "deleteUpdateCommitsDeadline",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "name": "epochStateCommitSubmissionExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -456,30 +475,11 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "epochStateId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getEpochStateCommitsCount",
-    "outputs": [
-      {
-        "internalType": "uint8",
-        "name": "",
-        "type": "uint8"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
         "name": "commitId",
         "type": "bytes32"
       }
     ],
-    "name": "getStateCommitSubmission",
+    "name": "getEpochStateCommitSubmission",
     "outputs": [
       {
         "components": [
@@ -520,7 +520,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getStateCommitSubmissionIdentityId",
+    "name": "getEpochStateCommitSubmissionIdentityId",
     "outputs": [
       {
         "internalType": "uint72",
@@ -539,7 +539,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getStateCommitSubmissionNextIdentityId",
+    "name": "getEpochStateCommitSubmissionNextIdentityId",
     "outputs": [
       {
         "internalType": "uint72",
@@ -558,7 +558,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getStateCommitSubmissionPrevIdentityId",
+    "name": "getEpochStateCommitSubmissionPrevIdentityId",
     "outputs": [
       {
         "internalType": "uint72",
@@ -577,12 +577,31 @@
         "type": "bytes32"
       }
     ],
-    "name": "getStateCommitSubmissionScore",
+    "name": "getEpochStateCommitSubmissionScore",
     "outputs": [
       {
         "internalType": "uint40",
         "name": "",
         "type": "uint40"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "epochStateId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getEpochStateCommitsCount",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",
@@ -880,7 +899,7 @@
         "type": "uint72"
       }
     ],
-    "name": "setStateCommitSubmissionIdentityId",
+    "name": "setEpochStateCommitSubmissionIdentityId",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -898,7 +917,7 @@
         "type": "uint72"
       }
     ],
-    "name": "setStateCommitSubmissionNextIdentityId",
+    "name": "setEpochStateCommitSubmissionNextIdentityId",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -916,7 +935,7 @@
         "type": "uint72"
       }
     ],
-    "name": "setStateCommitSubmissionPrevIdentityId",
+    "name": "setEpochStateCommitSubmissionPrevIdentityId",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -934,7 +953,7 @@
         "type": "uint40"
       }
     ],
-    "name": "setStateCommitSubmissionScore",
+    "name": "setEpochStateCommitSubmissionScore",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -955,25 +974,6 @@
     "name": "setUpdateCommitsDeadline",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "commitId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "stateCommitSubmissionExists",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/contracts/CommitManagerV1.sol
+++ b/contracts/CommitManagerV1.sol
@@ -235,6 +235,9 @@ contract CommitManagerV1 is Named, Versioned {
         );
 
         ServiceAgreementStorageProxy sasProxy = serviceAgreementStorageProxy;
+        AbstractAsset generalAssetInterface = AbstractAsset(args.assetContract);
+
+        bytes32 latestFinalizedState = generalAssetInterface.getLatestAssertionId(args.tokenId);
 
         if (!reqs[0] && !isCommitWindowOpen(agreementId, args.epoch)) {
             uint128 epochLength = sasProxy.getAgreementEpochLength(agreementId);
@@ -244,6 +247,7 @@ contract CommitManagerV1 is Named, Versioned {
             revert ServiceAgreementErrorsV1.CommitWindowClosed(
                 agreementId,
                 args.epoch,
+                latestFinalizedState,
                 actualCommitWindowStart,
                 actualCommitWindowStart + (parametersStorage.commitWindowDurationPerc() * epochLength) / 100,
                 block.timestamp
@@ -272,9 +276,6 @@ contract CommitManagerV1 is Named, Versioned {
             args.keyword,
             stakingStorage.totalStakes(identityId)
         );
-
-        AbstractAsset generalAssetInterface = AbstractAsset(args.assetContract);
-        bytes32 latestFinalizedState = generalAssetInterface.getLatestAssertionId(args.tokenId);
 
         _insertCommit(agreementId, args.epoch, latestFinalizedState, identityId, 0, 0, score);
 
@@ -316,6 +317,7 @@ contract CommitManagerV1 is Named, Versioned {
             revert ServiceAgreementErrorsV1.CommitWindowClosed(
                 agreementId,
                 args.epoch,
+                unfinalizedState,
                 commitWindowEnd - parametersStorage.updateCommitWindowDuration(),
                 commitWindowEnd,
                 block.timestamp
@@ -410,6 +412,7 @@ contract CommitManagerV1 is Named, Versioned {
             revert ServiceAgreementErrorsV1.NodeAlreadySubmittedCommit(
                 agreementId,
                 epoch,
+                assertionId,
                 identityId,
                 profileStorage.getNodeId(identityId)
             );
@@ -435,6 +438,7 @@ contract CommitManagerV1 is Named, Versioned {
             revert ServiceAgreementErrorsV1.NodeNotAwarded(
                 agreementId,
                 epoch,
+                assertionId,
                 identityId,
                 profileStorage.getNodeId(identityId),
                 i

--- a/contracts/ProofManagerV1.sol
+++ b/contracts/ProofManagerV1.sol
@@ -242,10 +242,7 @@ contract ProofManagerV1 is Named, Versioned {
         uint72 identityId = ids.getIdentityId(msg.sender);
         bytes32 commitId = keccak256(abi.encodePacked(agreementId, args.epoch, latestFinalizedState, identityId));
 
-        if (
-            !reqs[1] &&
-            (sasProxy.getCommitSubmissionScore(commitId) == 0)
-        )
+        if (!reqs[1] && (sasProxy.getCommitSubmissionScore(commitId) == 0))
             revert ServiceAgreementErrorsV1.NodeAlreadyRewarded(
                 agreementId,
                 args.epoch,

--- a/contracts/errors/ServiceAgreementErrorsV1.sol
+++ b/contracts/errors/ServiceAgreementErrorsV1.sol
@@ -21,6 +21,7 @@ library ServiceAgreementErrorsV1 {
     error CommitWindowClosed(
         bytes32 agreementId,
         uint16 epoch,
+        bytes32 state,
         uint256 commitWindowOpen,
         uint256 commitWindowClose,
         uint256 timeNow
@@ -29,15 +30,17 @@ library ServiceAgreementErrorsV1 {
     error ProofWindowClosed(
         bytes32 agreementId,
         uint16 epoch,
+        bytes32 state,
         uint256 proofWindowOpen,
         uint256 proofWindowClose,
         uint256 timeNow
     );
-    error NodeAlreadyRewarded(bytes32 agreementId, uint16 epoch, uint72 identityId, bytes nodeId);
-    error NodeNotAwarded(bytes32 agreementId, uint16 epoch, uint72 identityId, bytes nodeId, uint8 rank);
+    error NodeAlreadyRewarded(bytes32 agreementId, uint16 epoch, bytes32 state, uint72 identityId, bytes nodeId);
+    error NodeNotAwarded(bytes32 agreementId, uint16 epoch, bytes32 state, uint72 identityId, bytes nodeId, uint8 rank);
     error WrongMerkleProof(
         bytes32 agreementId,
         uint16 epoch,
+        bytes32 state,
         uint72 identityId,
         bytes nodeId,
         bytes32[] merkleProof,
@@ -45,7 +48,7 @@ library ServiceAgreementErrorsV1 {
         bytes32 chunkHash,
         uint256 challenge
     );
-    error NodeAlreadySubmittedCommit(bytes32 agreementId, uint16 epoch, uint72 identityId, bytes nodeId);
+    error NodeAlreadySubmittedCommit(bytes32 agreementId, uint16 epoch, bytes32 state, uint72 identityId, bytes nodeId);
     error CommitPhaseOngoing(bytes32 agreementId);
     error CommitPhaseSucceeded(bytes32 agreementId);
     error FirstEpochHasAlreadyEnded(bytes32 agreementId);

--- a/contracts/storage/ServiceAgreementStorageProxy.sol
+++ b/contracts/storage/ServiceAgreementStorageProxy.sol
@@ -298,14 +298,14 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         uint72 nextIdentityId,
         uint40 score
     ) external onlyContracts {
-        storageV1U1.createStateCommitSubmissionObject(commitId, identityId, prevIdentityId, nextIdentityId, score);
+        storageV1U1.createEpochStateCommitSubmissionObject(commitId, identityId, prevIdentityId, nextIdentityId, score);
     }
 
     function deleteCommitSubmissionsObject(bytes32 commitId) external onlyContracts {
         if (this.isOldCommit(commitId)) {
             storageV1.deleteCommitSubmissionsObject(commitId);
         } else {
-            storageV1U1.deleteStateCommitSubmissionsObject(commitId);
+            storageV1U1.deleteEpochStateCommitSubmissionsObject(commitId);
         }
     }
 
@@ -315,7 +315,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.getCommitSubmission(commitId);
         } else {
-            return storageV1U1.getStateCommitSubmission(commitId);
+            return storageV1U1.getEpochStateCommitSubmission(commitId);
         }
     }
 
@@ -323,7 +323,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.getCommitSubmissionIdentityId(commitId);
         } else {
-            return storageV1U1.getStateCommitSubmissionIdentityId(commitId);
+            return storageV1U1.getEpochStateCommitSubmissionIdentityId(commitId);
         }
     }
 
@@ -331,7 +331,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             storageV1.setCommitSubmissionIdentityId(commitId, identityId);
         } else {
-            storageV1U1.setStateCommitSubmissionIdentityId(commitId, identityId);
+            storageV1U1.setEpochStateCommitSubmissionIdentityId(commitId, identityId);
         }
     }
 
@@ -339,7 +339,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.getCommitSubmissionPrevIdentityId(commitId);
         } else {
-            return storageV1U1.getStateCommitSubmissionPrevIdentityId(commitId);
+            return storageV1U1.getEpochStateCommitSubmissionPrevIdentityId(commitId);
         }
     }
 
@@ -347,7 +347,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             storageV1.setCommitSubmissionPrevIdentityId(commitId, prevIdentityId);
         } else {
-            storageV1U1.setStateCommitSubmissionPrevIdentityId(commitId, prevIdentityId);
+            storageV1U1.setEpochStateCommitSubmissionPrevIdentityId(commitId, prevIdentityId);
         }
     }
 
@@ -355,7 +355,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.getCommitSubmissionNextIdentityId(commitId);
         } else {
-            return storageV1U1.getStateCommitSubmissionNextIdentityId(commitId);
+            return storageV1U1.getEpochStateCommitSubmissionNextIdentityId(commitId);
         }
     }
 
@@ -363,7 +363,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             storageV1.setCommitSubmissionNextIdentityId(commitId, nextIdentityId);
         } else {
-            storageV1U1.setStateCommitSubmissionNextIdentityId(commitId, nextIdentityId);
+            storageV1U1.setEpochStateCommitSubmissionNextIdentityId(commitId, nextIdentityId);
         }
     }
 
@@ -371,7 +371,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.getCommitSubmissionScore(commitId);
         } else {
-            return storageV1U1.getStateCommitSubmissionScore(commitId);
+            return storageV1U1.getEpochStateCommitSubmissionScore(commitId);
         }
     }
 
@@ -379,7 +379,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             storageV1.setCommitSubmissionScore(commitId, score);
         } else {
-            storageV1U1.setStateCommitSubmissionScore(commitId, score);
+            storageV1U1.setEpochStateCommitSubmissionScore(commitId, score);
         }
     }
 
@@ -387,7 +387,7 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
         if (this.isOldCommit(commitId)) {
             return storageV1.commitSubmissionExists(commitId);
         } else {
-            return storageV1U1.stateCommitSubmissionExists(commitId);
+            return storageV1U1.epochStateCommitSubmissionExists(commitId);
         }
     }
 
@@ -432,11 +432,11 @@ contract ServiceAgreementStorageProxy is Named, Versioned {
     }
 
     function isOldCommit(bytes32 commitId) external view returns (bool) {
-        return storageV1.commitSubmissionExists(commitId) && !storageV1U1.stateCommitSubmissionExists(commitId);
+        return storageV1.commitSubmissionExists(commitId) && !storageV1U1.epochStateCommitSubmissionExists(commitId);
     }
 
     function isNewCommit(bytes32 commitId) external view returns (bool) {
-        return !storageV1.commitSubmissionExists(commitId) && storageV1U1.stateCommitSubmissionExists(commitId);
+        return !storageV1.commitSubmissionExists(commitId) && storageV1U1.epochStateCommitSubmissionExists(commitId);
     }
 
     function latestStorageAddress() external view returns (address) {

--- a/contracts/storage/ServiceAgreementStorageV1U1.sol
+++ b/contracts/storage/ServiceAgreementStorageV1U1.sol
@@ -15,7 +15,7 @@ contract ServiceAgreementStorageV1U1 is Named, Versioned, Guardian {
     mapping(bytes32 => ServiceAgreementStructsV1.ExtendedServiceAgreement) internal serviceAgreements;
 
     // CommitId [keccak256(agreementId + epoch + assertionId + identityId)] => stateCommitSubmission
-    mapping(bytes32 => ServiceAgreementStructsV1.CommitSubmission) internal stateCommitSubmissions;
+    mapping(bytes32 => ServiceAgreementStructsV1.CommitSubmission) internal epochStateCommitSubmissions;
 
     // EpochStateId [keccak256(agreementId + epoch + assertionId)] => epochStateCommitsCount
     mapping(bytes32 => uint8) internal epochStateCommitsCount;
@@ -174,14 +174,14 @@ contract ServiceAgreementStorageV1U1 is Named, Versioned, Guardian {
         return serviceAgreements[agreementId].startTime != 0;
     }
 
-    function createStateCommitSubmissionObject(
+    function createEpochStateCommitSubmissionObject(
         bytes32 commitId,
         uint72 identityId,
         uint72 prevIdentityId,
         uint72 nextIdentityId,
         uint40 score
     ) external onlyContracts {
-        stateCommitSubmissions[commitId] = ServiceAgreementStructsV1.CommitSubmission({
+        epochStateCommitSubmissions[commitId] = ServiceAgreementStructsV1.CommitSubmission({
             identityId: identityId,
             prevIdentityId: prevIdentityId,
             nextIdentityId: nextIdentityId,
@@ -189,50 +189,50 @@ contract ServiceAgreementStorageV1U1 is Named, Versioned, Guardian {
         });
     }
 
-    function deleteStateCommitSubmissionsObject(bytes32 commitId) external onlyContracts {
-        delete stateCommitSubmissions[commitId];
+    function deleteEpochStateCommitSubmissionsObject(bytes32 commitId) external onlyContracts {
+        delete epochStateCommitSubmissions[commitId];
     }
 
-    function getStateCommitSubmission(
+    function getEpochStateCommitSubmission(
         bytes32 commitId
     ) external view returns (ServiceAgreementStructsV1.CommitSubmission memory) {
-        return stateCommitSubmissions[commitId];
+        return epochStateCommitSubmissions[commitId];
     }
 
-    function getStateCommitSubmissionIdentityId(bytes32 commitId) external view returns (uint72) {
-        return stateCommitSubmissions[commitId].identityId;
+    function getEpochStateCommitSubmissionIdentityId(bytes32 commitId) external view returns (uint72) {
+        return epochStateCommitSubmissions[commitId].identityId;
     }
 
-    function setStateCommitSubmissionIdentityId(bytes32 commitId, uint72 identityId) external onlyContracts {
-        stateCommitSubmissions[commitId].identityId = identityId;
+    function setEpochStateCommitSubmissionIdentityId(bytes32 commitId, uint72 identityId) external onlyContracts {
+        epochStateCommitSubmissions[commitId].identityId = identityId;
     }
 
-    function getStateCommitSubmissionPrevIdentityId(bytes32 commitId) external view returns (uint72) {
-        return stateCommitSubmissions[commitId].prevIdentityId;
+    function getEpochStateCommitSubmissionPrevIdentityId(bytes32 commitId) external view returns (uint72) {
+        return epochStateCommitSubmissions[commitId].prevIdentityId;
     }
 
-    function setStateCommitSubmissionPrevIdentityId(bytes32 commitId, uint72 prevIdentityId) external onlyContracts {
-        stateCommitSubmissions[commitId].prevIdentityId = prevIdentityId;
+    function setEpochStateCommitSubmissionPrevIdentityId(bytes32 commitId, uint72 prevIdentityId) external onlyContracts {
+        epochStateCommitSubmissions[commitId].prevIdentityId = prevIdentityId;
     }
 
-    function getStateCommitSubmissionNextIdentityId(bytes32 commitId) external view returns (uint72) {
-        return stateCommitSubmissions[commitId].nextIdentityId;
+    function getEpochStateCommitSubmissionNextIdentityId(bytes32 commitId) external view returns (uint72) {
+        return epochStateCommitSubmissions[commitId].nextIdentityId;
     }
 
-    function setStateCommitSubmissionNextIdentityId(bytes32 commitId, uint72 nextIdentityId) external onlyContracts {
-        stateCommitSubmissions[commitId].nextIdentityId = nextIdentityId;
+    function setEpochStateCommitSubmissionNextIdentityId(bytes32 commitId, uint72 nextIdentityId) external onlyContracts {
+        epochStateCommitSubmissions[commitId].nextIdentityId = nextIdentityId;
     }
 
-    function getStateCommitSubmissionScore(bytes32 commitId) external view returns (uint40) {
-        return stateCommitSubmissions[commitId].score;
+    function getEpochStateCommitSubmissionScore(bytes32 commitId) external view returns (uint40) {
+        return epochStateCommitSubmissions[commitId].score;
     }
 
-    function setStateCommitSubmissionScore(bytes32 commitId, uint40 score) external onlyContracts {
-        stateCommitSubmissions[commitId].score = score;
+    function setEpochStateCommitSubmissionScore(bytes32 commitId, uint40 score) external onlyContracts {
+        epochStateCommitSubmissions[commitId].score = score;
     }
 
-    function stateCommitSubmissionExists(bytes32 commitId) external view returns (bool) {
-        return stateCommitSubmissions[commitId].identityId != 0;
+    function epochStateCommitSubmissionExists(bytes32 commitId) external view returns (bool) {
+        return epochStateCommitSubmissions[commitId].identityId != 0;
     }
 
     function incrementEpochStateCommitsCount(bytes32 epochStateId) external onlyContracts {

--- a/contracts/storage/ServiceAgreementStorageV1U1.sol
+++ b/contracts/storage/ServiceAgreementStorageV1U1.sol
@@ -211,7 +211,10 @@ contract ServiceAgreementStorageV1U1 is Named, Versioned, Guardian {
         return epochStateCommitSubmissions[commitId].prevIdentityId;
     }
 
-    function setEpochStateCommitSubmissionPrevIdentityId(bytes32 commitId, uint72 prevIdentityId) external onlyContracts {
+    function setEpochStateCommitSubmissionPrevIdentityId(
+        bytes32 commitId,
+        uint72 prevIdentityId
+    ) external onlyContracts {
         epochStateCommitSubmissions[commitId].prevIdentityId = prevIdentityId;
     }
 
@@ -219,7 +222,10 @@ contract ServiceAgreementStorageV1U1 is Named, Versioned, Guardian {
         return epochStateCommitSubmissions[commitId].nextIdentityId;
     }
 
-    function setEpochStateCommitSubmissionNextIdentityId(bytes32 commitId, uint72 nextIdentityId) external onlyContracts {
+    function setEpochStateCommitSubmissionNextIdentityId(
+        bytes32 commitId,
+        uint72 nextIdentityId
+    ) external onlyContracts {
         epochStateCommitSubmissions[commitId].nextIdentityId = nextIdentityId;
     }
 


### PR DESCRIPTION
- Changed naming of the commit submission mapping in the new SA storage
- Fixed commitId calculation for commit scores storing
- Added missing event arguments