### PR TITLE
Implemented cooldown for OperatorFee change

### DIFF
--- a/abi/StakingV2.json
+++ b/abi/StakingV2.json
@@ -43,6 +43,27 @@
         "internalType": "uint72",
         "name": "identityId",
         "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timeNow",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "delayEnd",
+        "type": "uint96"
+      }
+    ],
+    "name": "OperatorFeeChangeOnCooldown",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
       }
     ],
     "name": "ProfileDoesntExist",
@@ -149,9 +170,9 @@
       },
       {
         "indexed": false,
-        "internalType": "uint8",
+        "internalType": "uint96",
         "name": "operatorFee",
-        "type": "uint8"
+        "type": "uint96"
       }
     ],
     "name": "OperatorFeeUpdated",

--- a/contracts/v2/Staking.sol
+++ b/contracts/v2/Staking.sol
@@ -202,11 +202,11 @@ contract StakingV2 is Named, Versioned, ContractStatus, Initializable {
         // TBD
     }
 
-    function getOperatorFee(uint72 identityId) public view returns (uint8) {
+    function getOperatorFee(uint72 identityId) external view returns (uint8) {
         return uint8(stakingStorage.operatorFees(identityId) & 127);
     }
 
-    function getOperatorFeeChangeCooldownEndTimestamp(uint72 identityId) public view returns (uint96) {
+    function getOperatorFeeChangeCooldownEndTimestamp(uint72 identityId) external view returns (uint96) {
         return stakingStorage.operatorFees(identityId) >> 7;
     }
 

--- a/contracts/v2/errors/StakingErrors.sol
+++ b/contracts/v2/errors/StakingErrors.sol
@@ -8,4 +8,5 @@ library StakingErrors {
     error WithdrawalPeriodPending(uint256 endTimestamp);
     error InvalidOperatorFee();
     error MaximumStakeExceeded(uint256 amount);
+    error OperatorFeeChangeOnCooldown(uint72 identityId, uint256 timeNow, uint96 delayEnd);
 }

--- a/deployments/parameters.json
+++ b/deployments/parameters.json
@@ -587,7 +587,7 @@
       "replacementWindowDurationPerc": "0",
       "rewardWithdrawalDelay": "300",
       "slashingFreezeDuration": "63072000",
-      "stakeWithdrawalDelay": "3600",
+      "stakeWithdrawalDelay": "2419200",
       "updateCommitWindowDuration": "1800"
     },
     "ProofManagerV1": {


### PR DESCRIPTION
Taking into account that we cannot redeploy Storage contracts on the Parachain, we're not able to add new variable to the `StakingStorage` contract in order to keep track of `operatorFee` change delays, so I've implemented a workaround.

We have `uint96` variable `operatorFee`, the `operatorFee` itself is in range `[0, 100]` (takes 7 bits), so we can easily store timestamp for cooldown end inside the same variable, which looks like this:

```
uint96 combinedData = (uint96(block.timestamp + cooldownDelay) << 7) | operatorFee;
```
`cooldownDelay` here is `stakeWithdrawalDelay` not to introduce a new variable


To get `operatorFee` from this variable:
```
uint96 operatorFee = combinedData & 127;
```

To get `timestamp` from this variable:
```
uint96 timestamp = combinedData >> 7;
```
