### PR TITLE
Update v2/CommitManagerV1U1 StateFinalized

### DIFF
--- a/abi/CommitManagerV2U1.json
+++ b/abi/CommitManagerV2U1.json
@@ -508,13 +508,13 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "assetContract",
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"

--- a/contracts/v2/CommitManagerV1U1.sol
+++ b/contracts/v2/CommitManagerV1U1.sol
@@ -38,8 +38,8 @@ contract CommitManagerV2U1 is Named, Versioned, ContractStatus, Initializable {
         uint40 score
     );
     event StateFinalized(
-        address assetContract,
-        uint256 tokenId,
+        address indexed assetContract,
+        uint256 indexed tokenId,
         bytes keyword,
         uint8 hashFunctionId,
         uint16 epoch,


### PR DESCRIPTION
Update v2/CommitManagerV1U1 StateFinalized to match v1/CommitManagerV1U1 event, they didn't match and node couldn't use new ABI for both contracts