### PR TITLE
Add revert for getServiceAgreement if service agreement doesn't exist

### DIFF
--- a/contracts/v1/errors/ServiceAgreementErrors.sol
+++ b/contracts/v1/errors/ServiceAgreementErrors.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.16;
+
+library ServiceAgreementErrors {
+    error ServiceAgreementDoesntExist(bytes32 agreementId);
+}

--- a/contracts/v1/storage/ServiceAgreementStorageProxy.sol
+++ b/contracts/v1/storage/ServiceAgreementStorageProxy.sol
@@ -10,6 +10,7 @@ import {Initializable} from "../interface/Initializable.sol";
 import {Named} from "../interface/Named.sol";
 import {Versioned} from "../interface/Versioned.sol";
 import {GeneralErrors} from "../errors/GeneralErrors.sol";
+import {ServiceAgreementErrors} from "../errors/ServiceAgreementErrors.sol";
 
 contract ServiceAgreementStorageProxy is Named, Versioned, HubDependent, Initializable {
     string private constant _NAME = "ServiceAgreementStorageProxy";
@@ -124,8 +125,10 @@ contract ServiceAgreementStorageProxy is Named, Versioned, HubDependent, Initial
                 [tokenAmount, storageV1U1.getAgreementUpdateTokenAmount(agreementId)],
                 scoreFunctionIdAndProofWindowOffsetPerc
             );
-        } else {
+        } else if (this.agreementV1U1Exists(agreementId)) {
             return storageV1U1.getAgreementData(agreementId);
+        } else {
+            revert ServiceAgreementErrors.ServiceAgreementDoesntExist(agreementId);
         }
     }
 


### PR DESCRIPTION
Adding revert for getServiceAgreement function so on node side we won't need to have two calls to the blockchain in the getter, but do that validation on the contract side.