### PR TITLE
reworked RandomSampling, RandomSamplingStorage and unit tests for them

### DIFF
--- a/abi/RandomSampling.json
+++ b/abi/RandomSampling.json
@@ -142,37 +142,6 @@
         "type": "uint256"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "delegator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "RewardsClaimed",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "epoch",
-        "type": "uint256"
-      },
-      {
         "indexed": false,
         "internalType": "uint256",
         "name": "score",
@@ -289,24 +258,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint72",
-        "name": "identityId",
-        "type": "uint72"
-      },
-      {
-        "internalType": "uint256",
-        "name": "epoch",
-        "type": "uint256"
-      }
-    ],
-    "name": "claimRewards",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/abi/RandomSamplingStorage.json
+++ b/abi/RandomSamplingStorage.json
@@ -111,6 +111,37 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "nodeEpochScorePerStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "DelegatorLastSettledNodeEpochScorePerStakeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "delegatorKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "scoreAdded",
         "type": "uint256"
       },
@@ -184,6 +215,31 @@
       }
     ],
     "name": "NodeEpochScoreAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalNodeEpochScorePerStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "NodeEpochScorePerStakeUpdated",
     "type": "event"
   },
   {
@@ -385,6 +441,29 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "uint256",
+        "name": "scorePerStakeToAdd",
+        "type": "uint256"
+      }
+    ],
+    "name": "addToNodeEpochScorePerStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "",
         "type": "uint256"
       },
@@ -432,6 +511,35 @@
         "internalType": "contract Chronos",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "",
+        "type": "uint72"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "delegatorLastSettledNodeEpochScorePerStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -566,6 +674,35 @@
       }
     ],
     "name": "getAllNodesEpochScore",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "delegatorKey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDelegatorLastSettledNodeEpochScorePerStake",
     "outputs": [
       {
         "internalType": "uint256",
@@ -835,6 +972,30 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      }
+    ],
+    "name": "getNodeEpochScorePerStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "hub",
     "outputs": [
@@ -954,6 +1115,30 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "",
+        "type": "uint72"
+      }
+    ],
+    "name": "nodeEpochScorePerStake",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint72",
         "name": "",
         "type": "uint72"
@@ -1038,6 +1223,34 @@
       }
     ],
     "name": "replacePendingProofingPeriodDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint72",
+        "name": "identityId",
+        "type": "uint72"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "delegatorKey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newNodeEpochScorePerStake",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDelegatorLastSettledNodeEpochScorePerStake",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/test/unit/RandomSampling.test.ts
+++ b/test/unit/RandomSampling.test.ts
@@ -51,7 +51,7 @@ describe('@unit RandomSampling', () => {
   describe('constructor', () => {
     it('Should set correct initial values', async () => {
       // Check initial values set in constructor
-      expect(await RandomSampling.avgBlockTimeInSeconds()).to.equal(avgBlockTimeInSeconds);
+      expect(await RandomSampling.avgBlockTimeInSeconds()).to.equal(BigInt(avgBlockTimeInSeconds));
       expect(await RandomSampling.w1()).to.equal(w1);
       expect(await RandomSampling.w2()).to.equal(w2);
     });
@@ -154,9 +154,9 @@ describe('@unit RandomSampling', () => {
       
       await expect(tx)
         .to.emit(RandomSampling, 'AvgBlockTimeUpdated')
-        .withArgs(newAvg);
+        .withArgs(BigInt(newAvg));
       
-      expect(await RandomSampling.avgBlockTimeInSeconds()).to.equal(newAvg);
+      expect(await RandomSampling.avgBlockTimeInSeconds()).to.equal(BigInt(newAvg));
 
       // Test revert for non-owner
       await expect(RandomSampling.connect(accounts[1]).setAvgBlockTimeInSeconds(newAvg))
@@ -169,4 +169,4 @@ describe('@unit RandomSampling', () => {
         .to.be.revertedWith('Block time in seconds must be greater than 0');
     });
   });
-}); 
+});


### PR DESCRIPTION
Random Sampling
submitProof
Removed _calculateAndStoreDelegatorScores function
Added nodeScorePerStake calculation in submitProof
Added nodeEpochScorePerStake variable into RandomSamplingStorage Add getter and increase functions, events
Added delegatorLastSettledNodeEpochScorePerStake
Added getters and setters, events
Modified getDelegatorEpochRewardsAmount to simulate score calculation based on currently available data (D.stakeBase * (N.nodeEpochScorePerStake - D.lastSettledNodeEpochScorePerStake)) Remove claimRewards and repurpose in Staking