### PR TITLE
Fix for scenario when delegator has rolling rewards, but node did not submit proof

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -607,9 +607,9 @@ contract Staking is INamed, IVersioned, ContractStatus, IInitializable {
             }
         }
 
-        if (reward == 0) return;
-
         uint256 rolling = delegatorsInfo.getDelegatorRollingRewards(identityId, delegator);
+
+        if (reward == 0 && rolling == 0) return;
 
         // if there are still older epochs pending, accumulate; otherwise restake immediately
         if ((currentEpoch - 1) - lastClaimedEpoch > 1) {


### PR DESCRIPTION
Fix for the scenario when a delegator has rolling rewards, but the node did not submit proof
In the current version, if the node did not submit proof for a given epoch, it does not receive rewards — and consequently, neither does the delegator. If the delegator had rolling rewards accumulated from previous epochs, they cannot be transferred to the stake base in this case, even if this is the final epoch the delegator would claim rewards for.